### PR TITLE
Add acl package to install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ base_ubuntu_packages:
   - apt-dater-host
   - net-tools
   - traceroute
+  - acl
 
 # @var base_ubuntu_additional:description: Additionally install on Ubuntu
 base_ubuntu_additional: []


### PR DESCRIPTION
Without adding acl to the package list all become actions within Ansible
can potentially fail. On Ubuntu 18.04 images this seem to be present,
but not for cloud images like 20.04, in this case become actions will
fail similar to this:

```
{"msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chown: changing ownership of '/var/tmp/ansible-tmp-1588573768.785264-73753078797684/': Operation not permitted\nchown: changing ownership of '/var/tmp/ansible-tmp-1588573768.785264-73753078797684/AnsiballZ_git.py': Operation not permitted\n}). For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"}
```